### PR TITLE
ENHANCE: Reset position once playback hits 100%

### DIFF
--- a/projects/ng-waveform/src/lib/ng-waveform.component.ts
+++ b/projects/ng-waveform/src/lib/ng-waveform.component.ts
@@ -129,6 +129,7 @@ export class NgWaveformComponent implements OnInit, OnChanges, OnDestroy, AfterV
         }
         if (this._progress > 100) {
           this.pause();
+          this.setCurrentTime(this.startPosition);
         }
       });
 
@@ -167,6 +168,15 @@ export class NgWaveformComponent implements OnInit, OnChanges, OnDestroy, AfterV
       this.srcUrl = this.src;
       this.loadAudio();
     }
+  }
+
+ /**
+   * Gets the time which playback should begin from
+   * Either the start of the region, or 0
+   * @returns start position
+   */
+  private get startPosition(): number {
+    return this.useRegion ? this.region.start : 0;
   }
 
   /**

--- a/projects/ng-waveform/src/lib/ng-waveform.component.ts
+++ b/projects/ng-waveform/src/lib/ng-waveform.component.ts
@@ -117,15 +117,20 @@ export class NgWaveformComponent implements OnInit, OnChanges, OnDestroy, AfterV
       ),
       switchMap(() => of(this.audioCtx.currentTime - this._audioContextStartTime + this._savedCurrentTime)),
     )
-    .subscribe(time => {
-      this._progress = time / this._duration * 100;
-      this.timeUpdate.emit({ time, progress: this._progress });
-      this._currentTime = time;
-      if (this.useRegion && this._stopAtRegionEnd && time > this.region.end) {
-        this.pause();
-        this._stopAtRegionEnd = false;
-      }
-    });
+      .subscribe(time => {
+        this._progress = time / this._duration * 100;
+        this.timeUpdate.emit({ time, progress: this._progress });
+        this._currentTime = time;
+        if (this.useRegion) {
+          if (this._stopAtRegionEnd && time > this.region.end) {
+            this.pause();
+            this._stopAtRegionEnd = false;
+          }
+        }
+        if (this._progress > 100) {
+          this.pause();
+        }
+      });
 
     this._durationSubj.asObservable().subscribe(duration => {
       this._duration = duration;


### PR DESCRIPTION
# Summary

Once playback hits 100%, the position will set either to the start of the region, or 0.

This PR depends on #12.

*NOTE: This won't reset the playback if it reaches the end of the region:* A discussion needs to be had about how the component should behave when playing outside the region. This approach won't work for resetting on region end, as if the user manually selects outside the region it would reset their position to start.

Hopefully can have a discussion below.

